### PR TITLE
:tada:Added prosody rate

### DIFF
--- a/lib/src/audio/audio_handler.dart
+++ b/lib/src/audio/audio_handler.dart
@@ -18,7 +18,8 @@ class AudioHandler {
         authHeader: BearerAuthenticationHeader(token: Config.authToken!.token),
         audioTypeHeader: AudioTypeHeader(audioFormat: params.audioFormat));
 
-    final ssml = Ssml(voice: params.voice, text: params.text);
+    final ssml =
+        Ssml(voice: params.voice, text: params.text, speed: params.rate ?? 1);
 
     final response = await audioClient.post(Uri.parse(Endpoints.audio),
         body: ssml.buildSsml);

--- a/lib/src/audio/audio_request_param.dart
+++ b/lib/src/audio/audio_request_param.dart
@@ -4,7 +4,12 @@ class AudioRequestParams {
   final Voice voice;
   final String text;
   final String audioFormat;
+  double? rate;
 
-  AudioRequestParams(
-      {required this.voice, required this.text, required this.audioFormat});
+  AudioRequestParams({
+    required this.voice,
+    required this.text,
+    required this.audioFormat,
+    this.rate,
+  });
 }

--- a/lib/src/ssml/ssml.dart
+++ b/lib/src/ssml/ssml.dart
@@ -1,10 +1,11 @@
 import 'package:flutter_azure_tts/src/voices/voice_model.dart';
 
 class Ssml {
-  Ssml({required this.voice, required this.text});
+  Ssml({required this.voice, required this.text, required this.speed});
 
   final Voice voice;
   final String text;
+  final double speed;
 
   String get buildSsml {
     return "<speak version='1.0' "
@@ -13,7 +14,8 @@ class Ssml {
         "<voice xml:lang='${voice.locale}' "
         "xml:gender='${voice.gender}' "
         "name='${voice.shortName}'>"
+        "<prosody rate='$speed'>"
         "$text"
-        "<\/voice><\/speak>";
+        "<\/prosody><\/voice><\/speak>";
   }
 }

--- a/lib/src/tts/tts_params.dart
+++ b/lib/src/tts/tts_params.dart
@@ -2,6 +2,19 @@ import 'package:flutter_azure_tts/src/audio/audio_request_param.dart';
 import 'package:flutter_azure_tts/src/voices/voices.dart';
 
 class TtsParams extends AudioRequestParams {
-  TtsParams({required Voice voice, required String audioFormat, required text})
-      : super(audioFormat: audioFormat, text: text, voice: voice);
+  /// Rate is the speed at which the voice will speak.
+  ///
+  /// * `rate` default to 1.
+
+  TtsParams({
+    required Voice voice,
+    required String audioFormat,
+    required text,
+    double? rate,
+  }) : super(
+          audioFormat: audioFormat,
+          text: text,
+          voice: voice,
+          rate: rate,
+        );
 }


### PR DESCRIPTION
Updated TtsParams

```
TtsParams params = TtsParams(
      voice: voice,
      audioFormat: AudioOutputFormat.audio16khz32kBitrateMonoMp3,
      text: text,
      rate: 1.5,
    );
```

Now, the user can control the speed at which the voice will speak.
The value of rate defaults to 1, which is the normal speed.

Azure references:
https://docs.microsoft.com/en-us/azure/cognitive-services/speech-service/speech-synthesis-markup?tabs=csharp